### PR TITLE
feat: add bytes crate buffer support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,13 @@ default = ["zmq_has"]
 # this feature is a no-op and only present for backward-compatibility;
 # it will be removed in the next API-breaking release.
 zmq_has = []
+bytes = ["dep:bytes"]
 
 [dependencies]
 bitflags = "1.0"
 libc = "0.2.15"
 zmq-sys = { version = "0.13.0", path = "zmq-sys" }
+bytes = { version = "1.11.1", optional = true }
 
 [dev-dependencies]
 trybuild = { version = "1" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -725,6 +725,28 @@ impl Socket {
         Ok(())
     }
 
+    /// Receive bytes into a `BufMut`. The length passed to `zmq_recv` is the
+    /// length of the `chunk_mut()` slice. The return value is the number of
+    /// bytes in the message, which may be larger than the length of the slice,
+    /// indicating truncation.
+    ///
+    /// Requires the `bytes` feature.
+    #[cfg(feature = "bytes")]
+    pub fn recv_buf<B: bytes::BufMut>(&self, mut buf: B, flags: i32) -> Result<usize> {
+        let bytes = buf.chunk_mut();
+        let bytes_ptr = bytes.as_mut_ptr() as *mut c_void;
+        let rc = zmq_try!(unsafe {
+            zmq_sys::zmq_recv(self.sock, bytes_ptr, bytes.len(), flags as c_int)
+        });
+        let msg_size = rc as usize;
+        let len = msg_size.min(bytes.len());
+        // SAFETY: This is safe because we've set `len` to the actual read size.
+        unsafe {
+            buf.advance_mut(len);
+        }
+        Ok(msg_size)
+    }
+
     /// Receive bytes into a slice. The length passed to `zmq_recv` is the length of the slice. The
     /// return value is the number of bytes in the message, which may be larger than the length of
     /// the slice, indicating truncation.

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -608,3 +608,44 @@ mod compile {
         run_mode("compile-fail");
     }
 }
+
+#[cfg(feature = "bytes")]
+mod bytes {
+    use bytes::BytesMut;
+
+    use super::create_socketpair;
+
+    test!(test_recv_buf_truncation, {
+        let (sender, receiver) = create_socketpair();
+        sender.send("bar", 0).unwrap();
+        assert_eq!(receiver.recv_bytes(0).unwrap(), b"bar");
+
+        let text = "a quite long string";
+
+        receiver.send(text, 0).unwrap();
+        let mut buf = BytesMut::with_capacity(10);
+        let len = sender.recv_buf(&mut buf, 0).unwrap(); // this should truncate the message
+
+        assert_eq!(len, text.len());
+        assert_eq!(buf.len(), 10);
+
+        assert_eq!(&buf[..], b"a quite lo");
+    });
+
+    test!(test_recv_buf, {
+        let (sender, receiver) = create_socketpair();
+        sender.send("bar", 0).unwrap();
+        assert_eq!(receiver.recv_bytes(0).unwrap(), b"bar");
+
+        let text = "a quite long string";
+
+        receiver.send(text, 0).unwrap();
+        let mut buf = BytesMut::with_capacity(128);
+        let len = sender.recv_buf(&mut buf, 0).unwrap(); // this should truncate the message
+
+        assert_eq!(len, text.len());
+        assert_eq!(buf.len(), text.len());
+
+        assert_eq!(&buf[..], text.as_bytes());
+    });
+}


### PR DESCRIPTION
Adds `recv_buf` to receive directly into a `BufMut`. The dependency is behind the feature flag `bytes`.